### PR TITLE
Update 404.html to support DA Live Preview

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,7 +9,7 @@
   </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:title" content="Page not found">
-  <script src="/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
+  <script src="/scripts/scripts.js" type="module"></script>
   <script type="module">
     import { sampleRUM } from '/scripts/aem.js';
 


### PR DESCRIPTION
Have 404.html match head.html credential behavior.

## Context
404.html has a legacy setting that tries to send credentials to cross origins. This is not advisable from a security standpoint and also makes CORs issues worse in that you cannot respond with a wildcard inside `access-control-allow-origin`.

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--coleman--kchauatadobe.hlx.live/
- After: https://<branch>--coleman--kchauatadobe.hlx.live/
